### PR TITLE
Adapting regenie_loco_regression to use linear_regression

### DIFF
--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -401,7 +401,6 @@ def test_regenie_loco_regression(ndarray_type: str, covariate: bool) -> None:
         # PREPARE SGKIT RESULTS
         dsr = res[
             [
-                "variant_linreg_effect",
                 "variant_linreg_t_value",
                 "variant_linreg_p_value",
                 "variant_id",
@@ -412,7 +411,6 @@ def test_regenie_loco_regression(ndarray_type: str, covariate: bool) -> None:
                 "traits": "outcomes",  # dimension name
                 "variant_linreg_p_value": "p_value",
                 "variant_linreg_t_value": "t_value",
-                "variant_linreg_effect": "effect",
             }
         )
         dsr = dsr.assign(outcome=xr.DataArray(df_trait.columns, dims=("outcomes")))
@@ -424,17 +422,16 @@ def test_regenie_loco_regression(ndarray_type: str, covariate: bool) -> None:
         df = pd.concat(
             [
                 sgkitres.set_index(["outcome", "variant_id"])[
-                    ["effect", "p_value", "t_value"]
+                    ["p_value", "t_value"]
                 ].add_suffix("_sgkit"),
                 glowres.set_index(["outcome", "variant_id"])[
-                    ["effect", "p_value", "t_value"]
+                    ["p_value", "t_value"]
                 ].add_suffix("_glow"),
             ],
             axis=1,
             join="outer",
         )
 
-        np.testing.assert_allclose(df["effect_sgkit"], df["effect_glow"], atol=atol)
         np.testing.assert_allclose(df["p_value_sgkit"], df["p_value_glow"], atol=atol)
         np.testing.assert_allclose(df["t_value_sgkit"], df["t_value_glow"], atol=atol)
 

--- a/sgkit/tests/test_regenie.py
+++ b/sgkit/tests/test_regenie.py
@@ -296,9 +296,12 @@ def check_simulation_result(
         check_stage_2_results(YMP, df_trait, result_dir)
 
         # Check equality of GWAS results
+        X = da.from_array(X)
+        Q = da.linalg.qr(X)[0]
         YR = Y - YMP
+        YP = YR - Q @ (Q.T @ YR)
         stats = linear_regression(
-            _dask_cupy_to_numpy(G.T), _dask_cupy_to_numpy(X), _dask_cupy_to_numpy(YR)
+            _dask_cupy_to_numpy(G.T), _dask_cupy_to_numpy(YP), _dask_cupy_to_numpy(Q)
         )
         check_stage_3_results(ds, stats, df_trait, result_dir)
 


### PR DESCRIPTION
- Removing `_inner_loco_regression` and `LinearRegressionResultLoco` 
- Changing `linear_regression` to use QR factorisation and projected outcomes
- Removing `effect` from the results of `regenie_loco_regression`
- Updating the tests to only check for p-values
- Changing `check_simulation_result` in `test_regenie.py` to use the updated `linear_regression`